### PR TITLE
add support for Array.foreach if not supported

### DIFF
--- a/springy.js
+++ b/springy.js
@@ -23,6 +23,33 @@ Copyright (c) 2010 Dennis Hotson
  OTHER DEALINGS IN THE SOFTWARE.
 */
 
+//https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/forEach
+if ( !Array.prototype.forEach ) {
+  Array.prototype.forEach = function( callback, thisArg ) {
+    var T, k;
+    if ( this == null ) {
+      throw new TypeError( " this is null or not defined" );
+    }
+    var O = Object(this);
+    var len = O.length >>> 0; // Hack to convert O.length to a UInt32
+    if ( {}.toString.call(callback) != "[object Function]" ) {
+      throw new TypeError( callback + " is not a function" );
+    }
+    if ( thisArg ) {
+      T = thisArg;
+    }
+    k = 0;
+    while( k < len ) {
+      var kValue;
+      if ( k in O ) {
+        kValue = O[ k ];
+        callback.call( T, kValue, k, O );
+      }
+      k++;
+    }
+  };
+}
+
 var Graph = function() {
 	this.nodeSet = {};
 	this.nodes = [];


### PR DESCRIPTION
It doesn't work in IE9. unless this is added. Not tested on other versions
