### PR TITLE
New click events methods added to SpringyUi and return the event object

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -36,7 +36,16 @@ jQuery(function(){
     graph: graph,
     nodeSelected: function(node){
       console.log('Node selected: ' + JSON.stringify(node.data));
+    },
+
+    nodeMouseUp: function(node, e){
+        console.log('MouseUp on '+node.data.label);
+    },
+
+    nodeDoubleClick: function(node, e){
+        console.log('Double clicked on '+node.data.label);
     }
+
   });
 });
 </script>

--- a/springyui.js
+++ b/springyui.js
@@ -32,6 +32,8 @@ jQuery.fn.springy = function(params) {
 	var repulsion = params.repulsion || 400.0;
 	var damping = params.damping || 0.5;
 	var nodeSelected = params.nodeSelected || null;
+    var nodeMouseUp = params.nodeMouseUp || null;
+    var nodeDoubleClick = params.nodeDoubleClick || null;
 
 	var canvas = this[0];
 	var ctx = canvas.getContext("2d");
@@ -76,31 +78,48 @@ jQuery.fn.springy = function(params) {
 	var nearest = null;
 	var dragged = null;
 
+    function fireNodeEvent(method, e, callback){
+
+        var pos = jQuery(this).offset();
+        var p = fromScreen({x: e.pageX - pos.left, y: e.pageY - pos.top});
+        selected = nearest = dragged = layout.nearest(p);
+
+        if (selected.node !== null) {
+            dragged.point.m = 10000.0;
+
+            if (method) {
+                method(selected.node, e);
+            }
+
+            if(callback){
+                callback(selected.node);
+            }
+
+        }
+
+        renderer.start();
+
+    }
+
 	jQuery(canvas).mousedown(function(e) {
-		var pos = jQuery(this).offset();
-		var p = fromScreen({x: e.pageX - pos.left, y: e.pageY - pos.top});
-		selected = nearest = dragged = layout.nearest(p);
-
-		if (selected.node !== null) {
-			dragged.point.m = 10000.0;
-
-			if (nodeSelected) {
-				nodeSelected(selected.node);
-			}
-		}
-
-		renderer.start();
+        fireNodeEvent.call(this, nodeSelected, e);
 	});
+
+    jQuery(canvas).mouseup(function(e) {
+        fireNodeEvent.call(this, nodeMouseUp, e);
+    });
 
 	// Basic double click handler
 	jQuery(canvas).dblclick(function(e) {
-		var pos = jQuery(this).offset();
-		var p = fromScreen({x: e.pageX - pos.left, y: e.pageY - pos.top});
-		selected = layout.nearest(p);
-		node = selected.node;
-		if (node && node.data && node.data.ondoubleclick) {
-			node.data.ondoubleclick();
-		}
+
+        fireNodeEvent.call(this, nodeDoubleClick, e, function(node){
+
+            if (node && node.data && node.data.ondoubleclick) {
+                node.data.ondoubleclick(e);
+            }
+
+        });
+
 	});
 
 	jQuery(canvas).mousemove(function(e) {


### PR DESCRIPTION
- Added generic function (fireNodeEvent) to receive the node events.
- Added two new methods on the springyui jQuery plugin, nodeMouseUp and nodeDoubleClick.
- The methods nodeSelected, nodeMouseUp and nodeDoubleClick returns the node and the event object, can be useful to detect the mouse position
