### PR TITLE
Browserify compatibility

### DIFF
--- a/springy.js
+++ b/springy.js
@@ -25,12 +25,12 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-(function() {
+;(function() {
 	// Enable strict mode for EC5 compatible browsers
 	"use strict";
 
 	// Establish the root object, `window` in the browser, or `global` on the server.
-	var root = this;
+	var root = Function('return this')();
 
 	// The top-level namespace. All public Springy classes and modules will
 	// be attached to this. Exported for both CommonJS and the browser.
@@ -694,4 +694,4 @@
 		}
 		return true;
 	};
-}).call(this);
+})();


### PR DESCRIPTION
Using 'this' to find the global means that the file can't be bundled in a 'use strict' file or into a definition function called on another object.  Function('return this')() always returns the global, regardless of whether you are in strict mode or not, and whatever function you have been called from.

I've also added a ; before the function definition, since if this file were concatenated with another that had no ending semicolon, bad things could happen.
