### PR TITLE
Allow configuration of minimum energy threshold

### DIFF
--- a/springy.js
+++ b/springy.js
@@ -325,11 +325,12 @@
 
 	// -----------
 	var Layout = Springy.Layout = {};
-	Layout.ForceDirected = function(graph, stiffness, repulsion, damping) {
+	Layout.ForceDirected = function(graph, stiffness, repulsion, damping, minEnergyThreshold) {
 		this.graph = graph;
 		this.stiffness = stiffness; // spring stiffness constant
 		this.repulsion = repulsion; // repulsion constant
 		this.damping = damping; // velocity damping factor
+		this.minEnergyThreshold = minEnergyThreshold || 0.01; //threshold used to determine render stop 
 
 		this.nodePoints = {}; // keep track of points associated with nodes
 		this.edgeSprings = {}; // keep track of springs associated with edges
@@ -508,7 +509,7 @@
 			}
 
 			// stop simulation when energy of the system goes below a threshold
-			if (t._stop || t.totalEnergy() < 0.01) {
+			if (t._stop || t.totalEnergy() < t.minEnergyThreshold) {
 				t._started = false;
 				if (onRenderStop !== undefined) { onRenderStop(); }
 			} else {


### PR DESCRIPTION
Hi dhotson

Please accept this humble backward-compatible change that allows one to configure the minimum energy threshold. 

(I found that increasing the threshold sped up the layout for graphs of over 30 nodes. I'm using just the springy layout provider with custom UI in ThreeJS.)

All the best

Daniel
