### PR TITLE
add maxSpeed parameter to Layout.ForceDirected constructor

### DIFF
--- a/springy.js
+++ b/springy.js
@@ -327,12 +327,13 @@
 
 	// -----------
 	var Layout = Springy.Layout = {};
-	Layout.ForceDirected = function(graph, stiffness, repulsion, damping, minEnergyThreshold) {
+	Layout.ForceDirected = function(graph, stiffness, repulsion, damping, minEnergyThreshold, maxSpeed) {
 		this.graph = graph;
 		this.stiffness = stiffness; // spring stiffness constant
 		this.repulsion = repulsion; // repulsion constant
 		this.damping = damping; // velocity damping factor
 		this.minEnergyThreshold = minEnergyThreshold || 0.01; //threshold used to determine render stop
+		this.maxSpeed = maxSpeed || Infinity; // nodes aren't allowed to exceed this speed
 
 		this.nodePoints = {}; // keep track of points associated with nodes
 		this.edgeSprings = {}; // keep track of springs associated with edges
@@ -451,6 +452,9 @@
 			// Is this, along with updatePosition below, the only places that your
 			// integration code exist?
 			point.v = point.v.add(point.a.multiply(timestep)).multiply(this.damping);
+			if (point.v.magnitude() > this.maxSpeed) {
+			    point.v = point.v.normalise().multiply(this.maxSpeed);
+			}
 			point.a = new Vector(0,0);
 		});
 	};


### PR DESCRIPTION
This adds a `maxSpeed` parameter to the `Layout.ForceDirected` constructor.  I added it because I was building a wall display and wanted to make keep the movement very smooth by ensuring the nodes couldn't exceed a certain speed.

Let me know what you think!  I'm happy to make any changes requested.
