### PR TITLE
Renderer.start has a done argument that is currently not being used

### DIFF
--- a/springy.js
+++ b/springy.js
@@ -675,6 +675,11 @@
 	 */
 	Renderer.prototype.start = function(done) {
 		var t = this;
+		var renderStop = function () {
+			t.onRenderStop && t.onRenderStop();
+			done && done();
+		}
+		
 		this.layout.start(function render() {
 			t.clear();
 
@@ -685,9 +690,9 @@
 			t.layout.eachNode(function(node, point) {
 				t.drawNode(node, point.p);
 			});
-			
+
 			if (t.onRenderFrame !== undefined) { t.onRenderFrame(); }
-		}, this.onRenderStop, this.onRenderStart);
+		}, renderStop, this.onRenderStart);
 	};
 
 	Renderer.prototype.stop = function() {


### PR DESCRIPTION
Support the currently unused done parameter passed into Renderer.start as well as the Renderer's onRenderStop function. Resolves #109.